### PR TITLE
feat: Use System.cmd instead of :os.cmd

### DIFF
--- a/lib/elixir_with_mjml_web/controllers/mjml_controller.ex
+++ b/lib/elixir_with_mjml_web/controllers/mjml_controller.ex
@@ -21,10 +21,14 @@ defmodule ElixirWithMjmlWeb.MjmlController do
 
   def compileMjml(conn, %{"mjmlTemplate" => mjmlTemplate}) when is_binary(mjmlTemplate) do
     with path <- :code.priv_dir(:elixir_with_mjml),
-      html <- :os.cmd(:"#{path}/mjml.sh '#{mjmlTemplate}'") |> IO.inspect do
-        render(conn, "index.json", message: sanitize(html))
+         {html, 0} <- System.cmd("#{path}/mjml.sh", [mjmlTemplate]) |> IO.inspect() do
+      render(conn, "index.json", message: sanitize(html))
     else
-        _error -> raise "Error MJML exited with non zero status"
+      {reason, exit_code} ->
+        raise "Error MJML exited with non zero status (status: #{exit_code}), reason: #{reason}"
+
+      error ->
+        raise "Unexpected error, error: #{inspect(error)}"
     end
   end
 


### PR DESCRIPTION
I couldn't reproduce the bug described in https://github.com/lukascivil/elixir_with_mjml/issues/1, but we found another one:

```elixir
[error] #PID<0.410.0> running ElixirWithMjmlWeb.Endpoint (connection #PID<0.409.0>, stream id 1) terminated
Server: localhost:4000 (http)
Request: POST /api/mjml
** (exit) an exception was raised:
    ** (SystemLimitError) a system limit has been reached
        :erlang.binary_to_atom("/home/victor/elixir_with_mjml/_build/dev/lib/elixir_with_mjml/priv/mjml.sh '<mjml><mj-body><mj-section><mj-column><mj-image width=\"100px\" src=\"/assets/img/logo-small.png\"></mj-image><mj-divider border-color=\"#F45E43\"></mj-divider><mj-text font-size=\"20px\" color=\"#F45E43\" font-family=\"helvetica\">Hello World</mj-text></mj-column></mj-section></mj-body></mjml>'", :utf8)
        (elixir_with_mjml) lib/elixir_with_mjml_web/controllers/mjml_controller.ex:26: ElixirWithMjmlWeb.MjmlController.compileMjml/2
        (elixir_with_mjml) lib/elixir_with_mjml_web/controllers/mjml_controller.ex:1: ElixirWithMjmlWeb.MjmlController.action/2
        (elixir_with_mjml) lib/elixir_with_mjml_web/controllers/mjml_controller.ex:1: ElixirWithMjmlWeb.MjmlController.phoenix_controller_pipeline/2
        (phoenix) lib/phoenix/router.ex:288: Phoenix.Router.__call__/2
        (elixir_with_mjml) lib/elixir_with_mjml_web/endpoint.ex:1: ElixirWithMjmlWeb.Endpoint.plug_builder_call/2
        (elixir_with_mjml) lib/plug/debugger.ex:122: ElixirWithMjmlWeb.Endpoint."call (overridable 3)"/2
        (elixir_with_mjml) lib/elixir_with_mjml_web/endpoint.ex:1: ElixirWithMjmlWeb.Endpoint.call/2
        (phoenix) lib/phoenix/endpoint/cowboy2_handler.ex:42: Phoenix.Endpoint.Cowboy2Handler.init/4
        (cowboy) /home/victor/elixir_with_mjml/deps/cowboy/src/cowboy_handler.erl:41: :cowboy_handler.execute/2
        (cowboy) /home/victor/elixir_with_mjml/deps/cowboy/src/cowboy_stream_h.erl:296: :cowboy_stream_h.execute/3
        (cowboy) /home/victor/elixir_with_mjml/deps/cowboy/src/cowboy_stream_h.erl:274: :cowboy_stream_h.request_process/3
        (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
```
